### PR TITLE
Fix skill profile area

### DIFF
--- a/app/assets/stylesheets/components/_skills-profile.scss
+++ b/app/assets/stylesheets/components/_skills-profile.scss
@@ -8,7 +8,8 @@
   @media screen and (min-width: $profile-breakpoint + 1) {
     display: flex;
     flex-direction: column;
-    flex-flow: column wrap;
+    flex-flow: wrap;
+    overflow: scroll;
     height: 164px;
 
     .skill-profile {


### PR DESCRIPTION
The area on a user's profile displaying skills was overflowing on the latest version of Firefox. It was a very quick fix:

* Change "flex-flow: column wrap" to "flex-flow: wrap"
* Add "overflow: scroll" rule


edit: Note that this only happens when you have more than 8 skills added to a profile.